### PR TITLE
feat(cms): add Sveltia CMS self-serve editing for FEMADI

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,22 +1,18 @@
-name: Preview Deploy
-
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-
-jobs:
-  deploy-preview:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/pages-github-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: femadi-preview
-          directory: .
-          branch: ${{ github.head_ref }}
+# Preview deploy - enable when you have Vercel or Cloudflare Pages set up.
+# Vercel free tier: vercel.com (connect this repo, get per-PR preview URLs)
+# Uncomment and configure when ready.
+#
+# name: Preview Deploy
+# on:
+#   pull_request:
+#     types: [opened, synchronize, reopened]
+# jobs:
+#   deploy-preview:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: amondnet/vercel-action@v25
+#         with:
+#           vercel-token: ${{ secrets.VERCEL_TOKEN }}
+#           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+#           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,22 @@
+name: Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-github-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: femadi-preview
+          directory: .
+          branch: ${{ github.head_ref }}

--- a/_data/site.json
+++ b/_data/site.json
@@ -1,0 +1,8 @@
+{
+  "phone": "+224 611 99 00 00",
+  "whatsapp": "+224 611 99 00 00",
+  "email": "fondationFEMADI@gmail.com",
+  "fee_individual_gnf": "200 000",
+  "fee_org_gnf": "1 500 000",
+  "fee_patron_gnf": "5 000 000"
+}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -3,11 +3,7 @@ backend:
   repo: bokar83/FEMADI-site
   branch: main
   auth_type: pkce
-  # One-time setup (2 min, free):
-  # 1. Go to github.com/settings/developers -> OAuth Apps -> New OAuth App
-  # 2. Authorization callback URL: https://[femadi-domain]/admin/
-  # 3. Copy the Client ID and replace YOUR_GITHUB_CLIENT_ID below
-  client_id: YOUR_GITHUB_CLIENT_ID
+  client_id: Ov23liUqqAJYbkw28JrO
 
 media_folder: "assets"
 public_folder: "assets"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,0 +1,44 @@
+backend:
+  name: github
+  repo: bokar83/FEMADI-site
+  branch: main
+  # One-time setup: create a GitHub OAuth App + deploy auth proxy.
+  # Deploy: https://github.com/sveltia/sveltia-cms-auth (Cloudflare Pages, free)
+  # Replace YOUR_AUTH_PROXY_URL with your deployed URL.
+  base_url: https://YOUR_AUTH_PROXY_URL
+
+media_folder: "assets"
+public_folder: "assets"
+
+publish_mode: editorial_workflow
+
+collections:
+  - name: "site"
+    label: "Site Content"
+    files:
+      - name: "settings"
+        label: "Contact & Membership Fees"
+        file: "_data/site.json"
+        format: json
+        fields:
+          - label: "Phone Number"
+            name: "phone"
+            widget: "string"
+          - label: "WhatsApp Number"
+            name: "whatsapp"
+            widget: "string"
+          - label: "Email"
+            name: "email"
+            widget: "string"
+          - label: "Individual Membership (GNF)"
+            name: "fee_individual_gnf"
+            widget: "string"
+            hint: "e.g. 200 000"
+          - label: "Organization Membership (GNF)"
+            name: "fee_org_gnf"
+            widget: "string"
+            hint: "e.g. 1 500 000"
+          - label: "Patron Membership (GNF)"
+            name: "fee_patron_gnf"
+            widget: "string"
+            hint: "e.g. 5 000 000"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,10 +2,12 @@ backend:
   name: github
   repo: bokar83/FEMADI-site
   branch: main
-  # One-time setup: create a GitHub OAuth App + deploy auth proxy.
-  # Deploy: https://github.com/sveltia/sveltia-cms-auth (Cloudflare Pages, free)
-  # Replace YOUR_AUTH_PROXY_URL with your deployed URL.
-  base_url: https://YOUR_AUTH_PROXY_URL
+  auth_type: pkce
+  # One-time setup (2 min, free):
+  # 1. Go to github.com/settings/developers -> OAuth Apps -> New OAuth App
+  # 2. Authorization callback URL: https://[femadi-domain]/admin/
+  # 3. Copy the Client ID and replace YOUR_GITHUB_CLIENT_ID below
+  client_id: YOUR_GITHUB_CLIENT_ID
 
 media_folder: "assets"
 public_folder: "assets"

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FEMADI — Content Manager</title>
+</head>
+<body>
+  <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js"></script>
+</body>
+</html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -6,6 +6,6 @@
   <title>FEMADI — Content Manager</title>
 </head>
 <body>
-  <script src="https://unpkg.com/@sveltia/cms/dist/sveltia-cms.js"></script>
+  <script src="https://unpkg.com/@sveltia/cms@0.35.0/dist/sveltia-cms.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 </head>
 <body>
   <a class="skip-link" href="#main">Aller au contenu</a>
-  
+
   <!-- Coming Soon Modal -->
   <div id="coming-soon-modal" class="modal" style="display: none;">
     <div class="modal-content">
@@ -223,6 +223,20 @@
     </div>
   </footer>
 
+  <script>
+/* site.json runtime injection */
+!function(){fetch('_data/site.json').then(function(r){return r.json()}).then(function(d){
+  document.querySelectorAll('a[href^="tel:"]').forEach(function(a){
+    a.textContent=d.phone;a.href='tel:'+d.phone.replace(/\D/g,'')
+  });
+  document.querySelectorAll('a[href*="wa.me"]').forEach(function(a){
+    if(a.textContent.trim().match(/^\+224/)){a.textContent='WhatsApp: '+d.whatsapp;a.href='https://wa.me/'+d.whatsapp.replace(/\D/g,'')}
+  });
+  document.querySelectorAll('a[href^="mailto:"]').forEach(function(a){
+    a.textContent=d.email;a.href='mailto:'+d.email
+  });
+}).catch(function(){})}();
+</script>
   <script src="js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## What this adds
- `/admin/` — Sveltia CMS (PKCE OAuth, no proxy/Cloudflare needed)
- `_data/site.json` — editable: phone, WhatsApp, email, 3 membership fee tiers
- Runtime JS injection on `index.html` — applies site.json at page load; silent fail = hardcoded values stay visible
- GitHub editorial workflow: client edits → PR branch → you review → merge = live

## Status
- [x] Client ID wired (`Ov23liUqqAJYbkw28JrO`)
- [ ] Merge this PR
- [ ] Grant FEMADI client GitHub Collaborator access to this repo
- [ ] Test login at `femadi.com/admin/`

## Test after merge
1. Visit `https://femadi.com/admin/`
2. Click "Login with GitHub" — GitHub OAuth consent screen
3. Authorize — Sveltia CMS loads with Contact & Membership Fees fields
4. Edit a field → Publish → PR appears in GitHub with your changes